### PR TITLE
Improve Makefile for cross-platform compatibility.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 MODULE_big = parquet_fdw
-OBJS = parquet.o parquet_fdw.o 
+OBJS = parquet_impl.o parquet_fdw.o
 PGFILEDESC = "parquet_fdw - foreign data wrapper for parquet"
 
 SHLIB_LINK = -lm -lstdc++ -lparquet -larrow
@@ -12,11 +12,22 @@ REGRESS = parquet_fdw
 EXTRA_CLEAN = sql/parquet_fdw.sql expected/parquet_fdw.out
 
 PG_CONFIG ?= pg_config
+
+# parquet_impl.cpp requires C++ 11.
+PG_CXXFLAGS += -std=c++11 -O3
+
 PGXS := $(shell $(PG_CONFIG) --pgxs)
+
+# pass CCFLAGS (when defined) to both C and C++ compilers.
+ifdef CCFLAGS
+	PG_CXXFLAGS += $(CCFLAGS)
+	PG_CFLAGS += $(CCFLAGS)
+endif
+
 include $(PGXS)
 
-parquet.bc:
-	$(COMPILE.cxx.bc) $(CCFLAGS) $(CPPFLAGS) -fPIC -c -o $@ parquet_impl.cpp
-
-parquet.o:
-	$(CXX) -std=c++11 -O3 $(CPPFLAGS) $(CCFLAGS) parquet_impl.cpp $(PG_LIBS) -c -fPIC $(LDFLAGS) $(LDFLAGS_EX) $(LIBS) -o $@$(X)
+# XXX: a hurdle to use common compiler flags when building bytecode from C++
+# files. should be not unnecessary, but src/Makefile.global omits passing those
+# flags for an unnknown reason.
+%.bc : %.cpp
+	$(COMPILE.cxx.bc) $(CXXFLAGS) $(CPPFLAGS)  -o $@ $<

--- a/Makefile
+++ b/Makefile
@@ -14,17 +14,24 @@ EXTRA_CLEAN = sql/parquet_fdw.sql expected/parquet_fdw.out
 PG_CONFIG ?= pg_config
 
 # parquet_impl.cpp requires C++ 11.
-PG_CXXFLAGS += -std=c++11 -O3
+override PG_CXXFLAGS += -std=c++11 -O3
 
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 
 # pass CCFLAGS (when defined) to both C and C++ compilers.
 ifdef CCFLAGS
-	PG_CXXFLAGS += $(CCFLAGS)
-	PG_CFLAGS += $(CCFLAGS)
+	override PG_CXXFLAGS += $(CCFLAGS)
+	override PG_CFLAGS += $(CCFLAGS)
 endif
 
 include $(PGXS)
+
+# XXX: PostgreSQL below 11 does not automatically add -fPIC or equivalent to C++
+# flags when building a shared library, have to do it here explicitely.
+ifeq ($(shell test $(VERSION_NUM) -lt 110000; echo $$?), 0)
+	override CXXFLAGS += $(CFLAGS_SL)
+endif
+
 
 # XXX: a hurdle to use common compiler flags when building bytecode from C++
 # files. should be not unnecessary, but src/Makefile.global omits passing those

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ or in case when PostgreSQL is installed in a custom location:
 ```sh
 make install PG_CONFIG=/path/to/pg_config
 ```
-Also additional compilation flags can be passed through `CCFLAGS` variable.
+It is possible to pass additional compilation flags through either custom
+`CCFLAGS` or standard `PG_CFLAGS`, `PG_CXXFLAGS`, `PG_CPPFLAGS` variables.
 
 After extension was successfully installed run in `psql`:
 ```sql


### PR DESCRIPTION
Instead of copy-pasting rules from Makefile.global (that has been done,
apparently, to accomodate CCFLAGS and use c++ 11 to compile from .cpp, we'll
use implicit rules when possible. The bytecode rule is, unfortunately, an
exception, since it doesn't pass any of the common build variables for an
unknown reason, so we have to take it from Makefile.global and modify.

The commit should fix complication on MacOS when -std=c++11 has not been passed
implicitely to the bytecode compiler (it's likely the defaults take care of
this on Linux).

This should also deprecate the ```cxxflags``` branch.