### PR TITLE
[Fix] ERROR:  parquet_fdw: integer out of range When use debug-mode parquet_fdw

### DIFF
--- a/parquet_impl.cpp
+++ b/parquet_impl.cpp
@@ -834,7 +834,6 @@ public:
         {
             MemoryContext   ccxt = CurrentMemoryContext;
             bool            error = false;
-            Datum           res;
             char            errstr[ERROR_STR_LEN];
 
             PG_TRY();


### PR DESCRIPTION
Remove the redundant 'res' variable in read_primitive_type() function.