### PR TITLE
Fix bug when reference test case  of postgres_fdw.sql

### DIFF
--- a/src/parquet_impl.cpp
+++ b/src/parquet_impl.cpp
@@ -1863,6 +1863,11 @@ parquetIsForeignScanParallelSafe(PlannerInfo * /* root */,
                                  RelOptInfo *rel,
                                  RangeTblEntry * /* rte */)
 {
+    /* Plan nodes that reference a correlated SubPlan is always parallel restricted. 
+     * Therefore, return false when there is lateral join.
+     */
+    if (rel->lateral_relids)
+        return false;
     return true;
 }
 

--- a/src/parquet_impl.cpp
+++ b/src/parquet_impl.cpp
@@ -1265,7 +1265,7 @@ parquetGetForeignPaths(PlannerInfo *root,
                                                     startup_cost,
                                                     total_cost,
                                                     NULL,   /* no pathkeys */
-                                                    NULL,	/* no outer rel either */
+                                                    baserel->lateral_relids,
                                                     NULL,	/* no extra plan */
                                                     (List *) fdw_private);
     if (!enable_multifile && is_multi)
@@ -1291,7 +1291,7 @@ parquetGetForeignPaths(PlannerInfo *root,
                                                 startup_cost,
                                                 total_cost,
                                                 pathkeys,
-                                                NULL,	/* no outer rel either */
+                                                baserel->lateral_relids,
                                                 NULL,	/* no extra plan */
                                                 (List *) private_sort);
 
@@ -1330,7 +1330,7 @@ parquetGetForeignPaths(PlannerInfo *root,
                                          startup_cost,
                                          total_cost,
                                          use_pathkeys ? pathkeys : NULL,
-                                         NULL,	/* no outer rel either */
+                                         baserel->lateral_relids,
                                          NULL,	/* no extra plan */
                                          (List *) private_parallel);
 
@@ -1365,7 +1365,7 @@ parquetGetForeignPaths(PlannerInfo *root,
                                              startup_cost,
                                              total_cost,
                                              pathkeys,
-                                             NULL,	/* no outer rel either */
+                                             baserel->lateral_relids,
                                              NULL,	/* no extra plan */
                                              (List *) private_parallel_merge);
 

--- a/src/parquet_impl.cpp
+++ b/src/parquet_impl.cpp
@@ -248,6 +248,15 @@ extract_rowgroup_filters(List *scan_clauses,
         else
             continue;
 
+        /*
+         * System columns should not be extract to filter, since
+         * we don't make any effort to ensure that local and
+         * remote values match (tableoid, in particular, almost
+         * certainly doesn't match).
+         */
+        if (v->varattno < 0)
+            continue;
+
         RowGroupFilter f
         {
             .attnum = v->varattno,

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1028,7 +1028,7 @@ public:
 
     void rescan(void)
     {
-        this->row_group = 0;
+        this->row_group = -1;
         this->row = 0;
         this->num_rows = 0;
     }
@@ -1380,7 +1380,7 @@ public:
 
     void rescan(void)
     {
-        this->row_group = 0;
+        this->row_group = -1;
         this->row = 0;
         this->num_rows = 0;
     }


### PR DESCRIPTION
* Fix crash if WHERE clause contain system column: ignore extract to filter for system column. 
Please check describe in commmit:
https://github.com/MinhLA1410/parquet_fdw/commit/c3e6aa261eafee3fb588c643fe29a3d46d7cec06

* Fix crash when lateral join in parallel mode: reference a correlated SubPlan is always parallel restricted.  
Please check describe in commmit:
https://github.com/MinhLA1410/parquet_fdw/commit/41c4fbe21e80e497263cd0721f8e0128189f8f9c

* Fix rescan wrong value for row_groups: row_group need rescan with -1 value.  
Please check describe in commmit: 
https://github.com/MinhLA1410/parquet_fdw/commit/7c89a77d615aed32a2f1f9da0b84f0b8d99c26c0

* Support lateral join: add baserel->lateral_relids when create_foreignscan_path.  
Please check describe in commmit: 
https://github.com/MinhLA1410/parquet_fdw/commit/535c6d7410509e9c248566ae9a71826007535a88

* Use FdwScanPrivateIndex: Indexes of FDW-private information stored in fdw_private lists.
Please check describe in commmit: 
https://github.com/MinhLA1410/parquet_fdw/commit/f040cc446543567025763dbe302e629cc02fda10