### PR TITLE
Log file name within extract_rowgroups_list()

### DIFF
--- a/src/parquet_impl.cpp
+++ b/src/parquet_impl.cpp
@@ -689,8 +689,8 @@ extract_rowgroups_list(const char *filename,
     }
     if (!error.empty()) {
         elog(ERROR,
-             "parquet_fdw: failed to exctract row groups from Parquet file: %s",
-             error.c_str());
+             "parquet_fdw: failed to extract row groups from Parquet file: %s ('%s')",
+             error.c_str(), filename);
     }
 
     return rowgroups;


### PR DESCRIPTION
From error `parquet_fdw: failed to exctract row groups from Parquet file` it is not clear what exact file caused it.