### PR TITLE
Issue 61: Quote identifiers during IMPORT FOREIGN SCHEMA

### DIFF
--- a/src/parquet_impl.cpp
+++ b/src/parquet_impl.cpp
@@ -824,7 +824,7 @@ create_foreign_table_query(const char *tablename,
     /* append table name */
     if (schemaname)
         appendStringInfo(&str, "%s.%s (",
-                         schemaname, quote_identifier(tablename));
+                         quote_identifier(schemaname), quote_identifier(tablename));
     else
         appendStringInfo(&str, "%s (", quote_identifier(tablename));
 
@@ -838,14 +838,14 @@ create_foreign_table_query(const char *tablename,
         const char *type_name = format_type_be(pg_type);
 
         if (!is_first)
-            appendStringInfo(&str, ", %s %s", name, type_name);
+            appendStringInfo(&str, ", %s %s", quote_identifier(name), type_name);
         else
         {
-            appendStringInfo(&str, "%s %s", name, type_name);
+            appendStringInfo(&str, "%s %s", quote_identifier(name), type_name);
             is_first = false;
         }
     }
-    appendStringInfo(&str, ") SERVER %s ", servername);
+    appendStringInfo(&str, ") SERVER %s ", quote_identifier(servername));
     appendStringInfo(&str, "OPTIONS (filename '");
 
     /* list paths */


### PR DESCRIPTION
It is necessary to quote identifiers like columns or schema names.
Unfortunately `parquet_fdw` still won't support column names with white spaces fully because of `sorted` option. `sorted` option accepts space separated list of columns and therefore it would be hard to fix this without breaking backward compatibility.

Issue: #61 