### PR TITLE
Remove std::move to support copy elision

### DIFF
--- a/src/exec_state.cpp
+++ b/src/exec_state.cpp
@@ -45,6 +45,7 @@ public:
     Size estimate_coord_size() 
     {
         Assert(false && "estimate_coord_size is not supported for TrivialExecutionState");
+        return 0;
     }
     void init_coord()
     {

--- a/src/parquet_impl.cpp
+++ b/src/parquet_impl.cpp
@@ -393,7 +393,7 @@ row_group_matches_filter(parquet::Statistics *stats,
                 Datum   lower;
                 int     cmpres;
                 bool    satisfies;
-                std::string min = std::move(stats->EncodeMin());
+                std::string min = stats->EncodeMin();
 
                 lower = bytes_to_postgres_type(min.c_str(), min.length(),
                                                arrow_type);
@@ -414,7 +414,7 @@ row_group_matches_filter(parquet::Statistics *stats,
                 Datum   upper;
                 int     cmpres;
                 bool    satisfies;
-                std::string max = std::move(stats->EncodeMax());
+                std::string max = stats->EncodeMax();
 
                 upper = bytes_to_postgres_type(max.c_str(), max.length(),
                                                arrow_type);
@@ -434,8 +434,8 @@ row_group_matches_filter(parquet::Statistics *stats,
             {
                 Datum   lower,
                         upper;
-                std::string min = std::move(stats->EncodeMin());
-                std::string max = std::move(stats->EncodeMax());
+                std::string min = stats->EncodeMin();
+                std::string max = stats->EncodeMax();
 
                 lower = bytes_to_postgres_type(min.c_str(), min.length(),
                                                arrow_type);


### PR DESCRIPTION
According to the standard, copy elision is allowed (before C++17) or required (since C++17) in the following situation:

In the initialization of an object, when the source object is a nameless temporary and is of the same class type (ignoring cv-qualification) as the target object. When the nameless temporary is the operand of a return statement, this variant of copy elision is known as RVO, "return value optimization".

Unfortunately, using std::move() will block this optimization when initializing an object, so it should not be used. Removing it allows the target object to be constructed in-place rather than being copied using the copy constructor.