### PR TITLE
Add file path into more error messages

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -166,7 +166,7 @@ void ParquetReader::create_column_mapping(TupleDesc tupleDesc, const std::set<in
     auto    p_schema = this->reader->parquet_reader()->metadata()->schema();
 
     if (!parquet::arrow::SchemaManifest::Make(p_schema, nullptr, props, &manifest).ok())
-        throw Error("error creating arrow schema ('%s')", this->filename);
+        throw Error("error creating arrow schema ('%s')", this->filename.c_str());
 
     this->map.resize(tupleDesc->natts);
     for (int i = 0; i < tupleDesc->natts; i++)
@@ -191,7 +191,7 @@ void ParquetReader::create_column_mapping(TupleDesc tupleDesc, const std::set<in
 
             if (field_name.length() > NAMEDATALEN)
                 throw Error("parquet column name '%s' is too long (max: %d, file: '%s')",
-                            field_name.c_str(), NAMEDATALEN - 1, this->filename);
+                            field_name.c_str(), NAMEDATALEN - 1, this->filename.c_str());
             tolowercase(schema_field.field->name().c_str(), arrow_colname);
 
             /*

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -893,8 +893,8 @@ public:
             ->ReadTable(this->indices, &this->table);
 
         if (!status.ok())
-            throw Error("failed to read rowgroup #%i: %s",
-                        rowgroup, status.message().c_str());
+            throw Error("failed to read rowgroup #%i: %s (%s)",
+                        rowgroup, status.message().c_str(), this->filename.c_str());
 
         if (!this->table)
             throw std::runtime_error("got empty table");
@@ -1128,8 +1128,8 @@ public:
             ->RowGroup(rowgroup)
             ->ReadTable(this->indices, &table);
         if (!status.ok())
-            throw Error("failed to read rowgroup #%i: %s",
-                        rowgroup, status.message().c_str());
+            throw Error("failed to read rowgroup #%i: %s (%s)",
+                        rowgroup, status.message().c_str(), this->filename.c_str());
 
         /* Release resources acquired in the previous iteration */
         allocator->recycle();

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -166,7 +166,7 @@ void ParquetReader::create_column_mapping(TupleDesc tupleDesc, const std::set<in
     auto    p_schema = this->reader->parquet_reader()->metadata()->schema();
 
     if (!parquet::arrow::SchemaManifest::Make(p_schema, nullptr, props, &manifest).ok())
-        throw std::runtime_error("error creating arrow schema");
+        throw Error("error creating arrow schema ('%s')", this->filename);
 
     this->map.resize(tupleDesc->natts);
     for (int i = 0; i < tupleDesc->natts; i++)
@@ -190,8 +190,8 @@ void ParquetReader::create_column_mapping(TupleDesc tupleDesc, const std::set<in
             char arrow_colname[255];
 
             if (field_name.length() > NAMEDATALEN)
-                throw Error("parquet column name '%s' is too long (max: %d)",
-                            field_name.c_str(), NAMEDATALEN - 1);
+                throw Error("parquet column name '%s' is too long (max: %d, file: '%s')",
+                            field_name.c_str(), NAMEDATALEN - 1, this->filename);
             tolowercase(schema_field.field->name().c_str(), arrow_colname);
 
             /*
@@ -841,8 +841,8 @@ public:
                         parquet::ParquetFileReader::OpenFile(filename, use_mmap),
                         &reader);
         if (!status.ok())
-            throw Error("failed to open Parquet file %s",
-                                 status.message().c_str());
+            throw Error("failed to open Parquet file %s ('%s')",
+                        status.message().c_str(), filename.c_str());
         this->reader = std::move(reader);
 
         /* Enable parallel columns decoding/decompression if needed */
@@ -893,7 +893,7 @@ public:
             ->ReadTable(this->indices, &this->table);
 
         if (!status.ok())
-            throw Error("failed to read rowgroup #%i: %s (%s)",
+            throw Error("failed to read rowgroup #%i: %s ('%s')",
                         rowgroup, status.message().c_str(), this->filename.c_str());
 
         if (!this->table)
@@ -1069,8 +1069,8 @@ public:
                         parquet::ParquetFileReader::OpenFile(filename, use_mmap),
                         &reader);
         if (!status.ok())
-            throw Error("failed to open Parquet file %s",
-                                 status.message().c_str());
+            throw Error("failed to open Parquet file %s ('%s')",
+                        status.message().c_str(), filename.c_str());
         this->reader = std::move(reader);
 
         /* Enable parallel columns decoding/decompression if needed */
@@ -1128,7 +1128,7 @@ public:
             ->RowGroup(rowgroup)
             ->ReadTable(this->indices, &table);
         if (!status.ok())
-            throw Error("failed to read rowgroup #%i: %s (%s)",
+            throw Error("failed to read rowgroup #%i: %s ('%s')",
                         rowgroup, status.message().c_str(), this->filename.c_str());
 
         /* Release resources acquired in the previous iteration */


### PR DESCRIPTION
Without file path in error messages it is hard to understand what file throws an error since a foreign table can have many parquet files.