### PR TITLE
feat(types): support unsigned data types

### DIFF
--- a/src/common.cpp
+++ b/src/common.cpp
@@ -51,10 +51,14 @@ to_postgres_type(int arrow_type)
         case arrow::Type::BOOL:
             return BOOLOID;
         case arrow::Type::INT8:
+        case arrow::Type::UINT8:
         case arrow::Type::INT16:
             return INT2OID;
+        case arrow::Type::UINT16:
         case arrow::Type::INT32:
             return INT4OID;
+        case arrow::Type::UINT32:
+        case arrow::Type::UINT64:
         case arrow::Type::INT64:
             return INT8OID;
         case arrow::Type::FLOAT:
@@ -63,6 +67,7 @@ to_postgres_type(int arrow_type)
             return FLOAT8OID;
         case arrow::Type::STRING:
             return TEXTOID;
+        case arrow::Type::FIXED_SIZE_BINARY:
         case arrow::Type::BINARY:
             return BYTEAOID;
         case arrow::Type::TIMESTAMP:
@@ -88,18 +93,27 @@ bytes_to_postgres_type(const char *bytes, Size len, const arrow::DataType *arrow
             return BoolGetDatum(*(bool *) bytes);
         case arrow::Type::INT8:
             return Int16GetDatum(*(int8 *) bytes);
+	case arrow::Type::UINT8:
+	    return UInt8GetDatum(*(uint8 *) bytes);
         case arrow::Type::INT16:
             return Int16GetDatum(*(int16 *) bytes);
+        case arrow::Type::UINT16:
+            return UInt16GetDatum(*(uint16 *) bytes);
         case arrow::Type::INT32:
             return Int32GetDatum(*(int32 *) bytes);
+        case arrow::Type::UINT32:
+            return UInt32GetDatum(*(uint32 *) bytes);
         case arrow::Type::INT64:
             return Int64GetDatum(*(int64 *) bytes);
+        case arrow::Type::UINT64:
+            return UInt64GetDatum(*(uint64 *) bytes);
         case arrow::Type::FLOAT:
             return Float4GetDatum(*(float *) bytes);
         case arrow::Type::DOUBLE:
             return Float8GetDatum(*(double *) bytes);
         case arrow::Type::STRING:
             return CStringGetTextDatum(bytes);
+        case arrow::Type::FIXED_SIZE_BINARY:
         case arrow::Type::BINARY:
             return PointerGetDatum(cstring_to_text_with_len(bytes, len));
         case arrow::Type::TIMESTAMP:

--- a/src/parquet_impl.cpp
+++ b/src/parquet_impl.cpp
@@ -859,7 +859,9 @@ create_foreign_table_query(const char *tablename,
         else
             is_first = false;
 
+        appendStringInfoChar(&str, '"');
         appendStringInfoString(&str, paths[i]);
+        appendStringInfoChar(&str, '"');
     }
     appendStringInfoChar(&str, '\'');
 

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -385,12 +385,28 @@ Datum ParquetReader::read_primitive_type(arrow::Array *array,
             res = Int8GetDatum(value);
             break;
         }
+        case arrow::Type::UINT8:
+        {
+            arrow::UInt8Array *uintarray = (arrow::UInt8Array *) array;
+            unsigned value = uintarray->Value(i);
+
+            res = UInt8GetDatum(value);
+            break;
+        }
         case arrow::Type::INT16:
         {
             arrow::Int16Array *intarray = (arrow::Int16Array *) array;
             int value = intarray->Value(i);
 
             res = Int16GetDatum(value);
+            break;
+        }
+        case arrow::Type::UINT16:
+        {
+            arrow::UInt16Array *uintarray = (arrow::UInt16Array *) array;
+            unsigned value = uintarray->Value(i);
+
+            res = UInt16GetDatum(value);
             break;
         }
         case arrow::Type::INT32:
@@ -401,12 +417,28 @@ Datum ParquetReader::read_primitive_type(arrow::Array *array,
             res = Int32GetDatum(value);
             break;
         }
+        case arrow::Type::UINT32:
+        {
+            arrow::UInt32Array *uintarray = (arrow::UInt32Array *) array;
+            unsigned value = uintarray->Value(i);
+
+            res = UInt32GetDatum(value);
+            break;
+        }
         case arrow::Type::INT64:
         {
             arrow::Int64Array *intarray = (arrow::Int64Array *) array;
             int64 value = intarray->Value(i);
 
             res = Int64GetDatum(value);
+            break;
+        }
+        case arrow::Type::UINT64:
+        {
+            arrow::UInt64Array *uintarray = (arrow::UInt64Array *) array;
+            uint64 value = uintarray->Value(i);
+
+            res = UInt64GetDatum(value);
             break;
         }
         case arrow::Type::FLOAT:
@@ -426,6 +458,7 @@ Datum ParquetReader::read_primitive_type(arrow::Array *array,
             break;
         }
         case arrow::Type::STRING:
+        case arrow::Type::FIXED_SIZE_BINARY:
         case arrow::Type::BINARY:
         {
             arrow::BinaryArray *binarray = (arrow::BinaryArray *) array;
@@ -505,7 +538,7 @@ Datum ParquetReader::nested_list_to_datum(arrow::ListArray *larray, int pos,
 
 #if SIZEOF_DATUM == 8
     /* Fill values and nulls arrays */
-    if (array->null_count() == 0 && typinfo.arrow.type_id == arrow::Type::INT64)
+    if (array->null_count() == 0 && (typinfo.arrow.type_id == arrow::Type::INT64 || typinfo.arrow.type_id == arrow::Type::UINT64))
     {
         /*
          * Ok, there are no nulls, so probably we could just memcpy the


### PR DESCRIPTION
Postgres does not support unsigned data types, but Parquet does. This causes problems when trying to import Parquet data using these types. So as to avoid having to preprocess all the Parquet to convert it from unsigned to signed, this change is to automatically convert the type in the wrapper. The number of bits is doubled during conversion, except in the case of uint64 which is converted to int64 (which may overflow).