### PR TITLE
compile against pg16 and later

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test/expected/*.out
 regression.diffs
 regression.out
 results
+.deps

--- a/src/common.cpp
+++ b/src/common.cpp
@@ -27,7 +27,7 @@ exc_palloc(std::size_t size)
 	void	   *ret;
 	MemoryContext context = CurrentMemoryContext;
 
-	AssertArg(MemoryContextIsValid(context));
+	Assert(MemoryContextIsValid(context));
 
 	if (!AllocSizeIsValid(size))
 		throw std::bad_alloc();

--- a/src/parquet_impl.cpp
+++ b/src/parquet_impl.cpp
@@ -331,8 +331,7 @@ convert_const(Const *c, Oid dst_oid)
                 getTypeOutputInfo(c->consttype, &output_fn, &isvarlena);
                 getTypeInputInfo(dst_oid, &input_fn, &input_param);
 
-                str = DatumGetCString(OidOutputFunctionCall(output_fn,
-                                                            c->constvalue));
+                str = OidOutputFunctionCall(output_fn, c->constvalue);
                 newc->constvalue = OidInputFunctionCall(input_fn, str,
                                                         input_param, 0);
 
@@ -950,7 +949,11 @@ get_filenames_from_userfunc(const char *funcname, const char *funcarg)
 {
     Jsonb      *j = NULL;
     Oid         funcid;
+#if PG_VERSION_NUM < 160000
     List       *f = stringToQualifiedNameList(funcname);
+#else
+    List       *f = stringToQualifiedNameList(funcname, NULL);
+#endif
     Datum       filenames;
     Oid         jsonboid = JSONBOID;
     Datum      *values;
@@ -1265,7 +1268,11 @@ parquetGetForeignPaths(PlannerInfo *root,
                                  NULL);
 
         /* Create PathKey for the attribute from "sorted" option */
+#if PG_VERSION_NUM < 160000
         attr_pathkeys = build_expression_pathkey(root, (Expr *) var, NULL,
+#else
+        attr_pathkeys = build_expression_pathkey(root, (Expr *) var,
+#endif
                                                 sort_op, baserel->relids,
                                                 true);
 
@@ -2081,7 +2088,11 @@ parquet_fdw_validator_impl(PG_FUNCTION_ARGS)
         else if (strcmp(def->defname, "files_func") == 0)
         {
             Oid     jsonboid = JSONBOID;
+#if PG_VERSION_NUM < 160000
             List   *funcname = stringToQualifiedNameList(defGetString(def));
+#else
+            List   *funcname = stringToQualifiedNameList(defGetString(def), NULL);
+#endif
             Oid     funcoid;
             Oid     rettype;
 


### PR DESCRIPTION
some changes ([1][2][3]) have been made in pg release 16,
adapt those changes to make parquet_fdw compile again.

[1] b448f1c8d
[2] b1099eca8
[3] 858e776c8