### PR TITLE
Issues 80: Fix typos in src/exec_state.cpp and src/parquet_impl.cpp

### DIFF
--- a/src/exec_state.cpp
+++ b/src/exec_state.cpp
@@ -235,7 +235,7 @@ public:
             ExecStoreVirtualTuple(slot);
         }
 
-        return res;
+        return res == RS_SUCCESS;
     }
 
     void rescan(void)

--- a/src/parquet_fdw.c
+++ b/src/parquet_fdw.c
@@ -1,15 +1,9 @@
 #include "postgres.h"
 #include "fmgr.h"
 
-#include "access/reloptions.h"
-#include "catalog/pg_foreign_table.h"
-#include "commands/defrem.h"
 #include "commands/explain.h"
 #include "foreign/fdwapi.h"
-#include "optimizer/planmain.h"
-#include "utils/builtins.h"
 #include "utils/guc.h"
-#include "utils/elog.h"
 
 
 PG_MODULE_MAGIC;

--- a/src/parquet_impl.cpp
+++ b/src/parquet_impl.cpp
@@ -12,16 +12,11 @@
 #include <list>
 #include <set>
 
-#include "arrow/api.h"
-#include "arrow/io/api.h"
-#include "arrow/array.h"
 #include "parquet/arrow/reader.h"
 #include "parquet/arrow/schema.h"
-#include "parquet/exception.h"
 #include "parquet/file_reader.h"
 #include "parquet/statistics.h"
 
-#include "heap.hpp"
 #include "exec_state.hpp"
 #include "reader.hpp"
 #include "common.hpp"
@@ -31,10 +26,9 @@ extern "C"
 #include "postgres.h"
 
 #include "access/htup_details.h"
-#include "access/parallel.h"
-#include "access/sysattr.h"
 #include "access/nbtree.h"
 #include "access/reloptions.h"
+#include "access/sysattr.h"
 #include "catalog/pg_foreign_table.h"
 #include "catalog/pg_type.h"
 #include "commands/defrem.h"
@@ -45,7 +39,6 @@ extern "C"
 #include "foreign/fdwapi.h"
 #include "miscadmin.h"
 #include "nodes/execnodes.h"
-#include "nodes/nodeFuncs.h"
 #include "nodes/makefuncs.h"
 #include "optimizer/cost.h"
 #include "optimizer/pathnode.h"
@@ -55,15 +48,12 @@ extern "C"
 #include "parser/parse_coerce.h"
 #include "parser/parse_func.h"
 #include "parser/parse_oper.h"
-#include "parser/parse_type.h"
 #include "utils/builtins.h"
 #include "utils/jsonb.h"
 #include "utils/lsyscache.h"
 #include "utils/memutils.h"
-#include "utils/memdebug.h"
 #include "utils/regproc.h"
 #include "utils/rel.h"
-#include "utils/timestamp.h"
 #include "utils/typcache.h"
 
 #if PG_VERSION_NUM < 120000
@@ -71,7 +61,6 @@ extern "C"
 #include "optimizer/var.h"
 #else
 #include "access/table.h"
-#include "access/relation.h"
 #include "optimizer/optimizer.h"
 #endif
 
@@ -393,7 +382,7 @@ row_group_matches_filter(parquet::Statistics *stats,
                 Datum   lower;
                 int     cmpres;
                 bool    satisfies;
-                std::string min = std::move(stats->EncodeMin());
+                std::string min = stats->EncodeMin();
 
                 lower = bytes_to_postgres_type(min.c_str(), min.length(),
                                                arrow_type);
@@ -414,7 +403,7 @@ row_group_matches_filter(parquet::Statistics *stats,
                 Datum   upper;
                 int     cmpres;
                 bool    satisfies;
-                std::string max = std::move(stats->EncodeMax());
+                std::string max = stats->EncodeMax();
 
                 upper = bytes_to_postgres_type(max.c_str(), max.length(),
                                                arrow_type);
@@ -434,8 +423,8 @@ row_group_matches_filter(parquet::Statistics *stats,
             {
                 Datum   lower,
                         upper;
-                std::string min = std::move(stats->EncodeMin());
-                std::string max = std::move(stats->EncodeMax());
+                std::string min = stats->EncodeMin();
+                std::string max = stats->EncodeMax();
 
                 lower = bytes_to_postgres_type(min.c_str(), min.length(),
                                                arrow_type);
@@ -1386,7 +1375,7 @@ parquetGetForeignPaths(PlannerInfo *root,
             private_parallel_merge->type = private_parallel_merge->max_open_files > 0 ?
                 RT_CACHING_MULTI_MERGE : RT_MULTI_MERGE;
 
-            Path *path = (Path *)
+            path = (Path *)
                      create_foreignscan_path(root, baserel,
                                              NULL,	/* default pathtarget */
                                              baserel->rows,
@@ -1397,7 +1386,7 @@ parquetGetForeignPaths(PlannerInfo *root,
                                              NULL,	/* no extra plan */
                                              (List *) private_parallel_merge);
 
-            int num_workers = max_parallel_workers_per_gather;
+            num_workers = max_parallel_workers_per_gather;
 
             cost_merge(path, list_length(private_parallel_merge->filenames),
                        startup_cost, total_cost, private_parallel_merge->matched_rows);
@@ -1479,7 +1468,7 @@ parquetGetForeignPlan(PlannerInfo * /* root */,
 extern "C" void
 parquetBeginForeignScan(ForeignScanState *node, int /* eflags */)
 {
-    ParquetFdwExecutionState   *festate;
+    ParquetFdwExecutionState   *festate = NULL;
     MemoryContextCallback      *callback;
     MemoryContext   reader_cxt;
 	ForeignScan    *plan = (ForeignScan *) node->ss.ps.plan;
@@ -2040,7 +2029,7 @@ parquet_fdw_validator_impl(PG_FUNCTION_ARGS)
 {
     List       *options_list = untransformRelOptions(PG_GETARG_DATUM(0));
     Oid         catalog = PG_GETARG_OID(1);
-    ListCell   *lc;
+    ListCell   *opt_lc;
     bool        filename_provided = false;
     bool        func_provided = false;
 
@@ -2048,22 +2037,22 @@ parquet_fdw_validator_impl(PG_FUNCTION_ARGS)
     if (catalog != ForeignTableRelationId)
         PG_RETURN_VOID();
 
-    foreach(lc, options_list)
+    foreach(opt_lc, options_list)
     {
-        DefElem    *def = (DefElem *) lfirst(lc);
+        DefElem    *def = (DefElem *) lfirst(opt_lc);
 
         if (strcmp(def->defname, "filename") == 0)
         {
             char   *filename = pstrdup(defGetString(def));
             List   *filenames;
-            ListCell *lc;
+            ListCell *file_lc;
 
             filenames = parse_filenames_list(filename);
 
-            foreach(lc, filenames)
+            foreach(file_lc, filenames)
             {
                 struct stat stat_buf;
-                char       *fn = strVal(lfirst(lc));
+                char       *fn = strVal(lfirst(file_lc));
 
                 if (stat(fn, &stat_buf) != 0)
                 {

--- a/src/parquet_impl.cpp
+++ b/src/parquet_impl.cpp
@@ -1792,7 +1792,7 @@ parquetAcquireSampleRowsFunc(Relation relation, int /* elevel */,
 
     delete festate;
 
-    return cnt - 1;
+    return cnt;
 }
 
 extern "C" bool

--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -1,11 +1,7 @@
 #include <list>
 
-#include "arrow/api.h"
-#include "arrow/io/api.h"
-#include "arrow/array.h"
 #include "parquet/arrow/reader.h"
 #include "parquet/arrow/schema.h"
-#include "parquet/exception.h"
 #include "parquet/file_reader.h"
 #include "parquet/statistics.h"
 

--- a/src/reader.hpp
+++ b/src/reader.hpp
@@ -2,7 +2,6 @@
 #define PARQUET_FDW_READER_HPP
 
 #include <memory>
-#include <mutex>
 #include <set>
 #include <vector>
 
@@ -15,7 +14,6 @@ extern "C"
 #include "fmgr.h"
 #include "access/tupdesc.h"
 #include "executor/tuptable.h"
-#include "nodes/pg_list.h"
 #include "storage/spin.h"
 }
 


### PR DESCRIPTION
- Fix typos in src/exec_state.cpp and src/parquet_impl.cpp mentioned in the issue #80 
- Fix clang warnings:
```
warning: moving a temporary object prevents copy elision [-Wpessimizing-move]
...
warning: ‘festate’ may be used uninitialized [-Wmaybe-uninitialized]
...
warning: declaration of ‘path’ shadows a previous local [-Wshadow=compatible-local]
```