### PR TITLE
Issue #82: Fix typos during row_group reset

### DIFF
--- a/src/reader.cpp
+++ b/src/reader.cpp
@@ -875,6 +875,7 @@ public:
          * row_group cannot be less than zero at this point so it is safe to cast
          * it to unsigned int
          */
+        Assert(this->row_group >= 0);
         if ((uint) this->row_group >= this->rowgroups.size())
             return false;
 
@@ -1024,7 +1025,7 @@ public:
 
     void rescan(void)
     {
-        this->row_group = 0;
+        this->row_group = -1;
         this->row = 0;
         this->num_rows = 0;
     }
@@ -1111,6 +1112,7 @@ public:
          * row_group cannot be less than zero at this point so it is safe to cast
          * it to unsigned int
          */
+        Assert(this->row_group >= 0);
         if ((uint) this->row_group >= this->rowgroups.size())
             return false;
 
@@ -1376,7 +1378,7 @@ public:
 
     void rescan(void)
     {
-        this->row_group = 0;
+        this->row_group = -1;
         this->row = 0;
         this->num_rows = 0;
     }

--- a/test/expected/001_parquet_fdw.out.in
+++ b/test/expected/001_parquet_fdw.out.in
@@ -489,6 +489,48 @@ SELECT SUM(one) FROM example1;
   21
 (1 row)
 
+-- test rescan
+SET enable_material = false;
+EXPLAIN (COSTS OFF)
+SELECT e1.one, e2.one FROM example1 e1, (SELECT * FROM example1) e2 WHERE e1.one < e2.one ORDER BY 1, 2;
+                       QUERY PLAN                       
+--------------------------------------------------------
+ Sort
+   Sort Key: e1.one, example1.one
+   ->  Nested Loop
+         Join Filter: (e1.one < example1.one)
+         ->  Gather
+               Workers Planned: 2
+               ->  Parallel Foreign Scan on example1 e1
+                     Reader: Single File
+                     Row groups: 1, 2
+         ->  Gather
+               Workers Planned: 2
+               ->  Parallel Foreign Scan on example1
+                     Reader: Single File
+                     Row groups: 1, 2
+(14 rows)
+
+SELECT e1.one, e2.one FROM example1 e1, (SELECT * FROM example1) e2 WHERE e1.one < e2.one ORDER BY 1, 2;
+ one | one 
+-----+-----
+   1 |   2
+   1 |   3
+   1 |   4
+   1 |   5
+   1 |   6
+   2 |   3
+   2 |   4
+   2 |   5
+   2 |   6
+   3 |   4
+   3 |   5
+   3 |   6
+   4 |   5
+   4 |   6
+   5 |   6
+(15 rows)
+
 -- multiple sorting keys
 CREATE FOREIGN TABLE example_multisort (
     one     INT8,

--- a/test/sql/001_parquet_fdw.sql.in
+++ b/test/sql/001_parquet_fdw.sql.in
@@ -172,6 +172,12 @@ EXPLAIN (COSTS OFF) SELECT * FROM example_sorted ORDER BY one;
 EXPLAIN (COSTS OFF) SELECT * FROM example1;
 SELECT SUM(one) FROM example1;
 
+-- test rescan
+SET enable_material = false;
+EXPLAIN (COSTS OFF)
+SELECT e1.one, e2.one FROM example1 e1, (SELECT * FROM example1) e2 WHERE e1.one < e2.one ORDER BY 1, 2;
+SELECT e1.one, e2.one FROM example1 e1, (SELECT * FROM example1) e2 WHERE e1.one < e2.one ORDER BY 1, 2;
+
 -- multiple sorting keys
 CREATE FOREIGN TABLE example_multisort (
     one     INT8,


### PR DESCRIPTION
Fixes the issue #82 
Added rescan test to test `parquetReScanForeignScan()`.