### PR TITLE
Globbing for directory and file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ options (
 );
 ```
 
+You can use [globbing](https://en.wikipedia.org/wiki/Glob_(programming)) to list all the Parquet files, like `options (filename '/mnt/userdata*.parquet')` and it will import all matching files. This can be usefull when you have a Hive directory structure, for instance organized by `year/month/day` and you can consider all Parquet files with `/mnt/userdata/**/*.parquet`.
+
 ## Advanced
 
 Currently `parquet_fdw` supports the following column [types](https://github.com/apache/arrow/blob/master/cpp/src/arrow/type.h):

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ options (
 );
 ```
 
-You can use [globbing](https://en.wikipedia.org/wiki/Glob_(programming)) to list all the Parquet files, like `options (filename '/mnt/userdata*.parquet')` and it will import all matching files. This can be usefull when you have a Hive directory structure, for instance organized by `year/month/day` and you can consider all Parquet files with `/mnt/userdata/**/*.parquet`.
+You can use [globbing](https://en.wikipedia.org/wiki/Glob_(programming)) to list all the Parquet files, like `options (filename '/mnt/userdata*.parquet')` and it will import all matching files. This can be usefull when you have a Hive directory structure, for instance organized by `year/month/day` and you can consider all Parquet files with `/mnt/userdata/**/*.parquet`. You can also use name enumerations using braces like `/mnt/userdata/data_{1,3}.parquet` that will consider only files `data_1.parquet` and `data_3.parquet`.
 
 ## Advanced
 

--- a/src/exec_state.cpp
+++ b/src/exec_state.cpp
@@ -45,6 +45,7 @@ public:
     Size estimate_coord_size() 
     {
         Assert(false && "estimate_coord_size is not supported for TrivialExecutionState");
+        return 0;
     }
     void init_coord()
     {

--- a/src/parquet_impl.cpp
+++ b/src/parquet_impl.cpp
@@ -540,7 +540,7 @@ lappend_globbed_filenames(List *filenames,
     glob_t  globbuf;
 
     globbuf.gl_offs = 0;
-    int error = glob(filename, GLOB_ERR | GLOB_NOCHECK, NULL, &globbuf);
+    int error = glob(filename, GLOB_ERR | GLOB_NOCHECK | GLOB_BRACE, NULL, &globbuf);
     switch (error) {
         case 0:
             for (size_t i = globbuf.gl_offs; i < globbuf.gl_pathc; i++)


### PR DESCRIPTION
- Add the ability to use [globbing](https://en.wikipedia.org/wiki/Glob_(programming)) to Parquet file names. For instance, instead of writing

```sql
CREATE FOREIGN TABLE test_parquet (
...
) SERVER parquet_srv OPTIONS (filename 'GoogleAnalytics/test/data_0.parquet GoogleAnalytics/test/data_1.parquet GoogleAnalytics/test/data_2.parquet');
```

you can use a globbing pattern for the directory or the file names like you would do in a Linux shell:

```
CREATE FOREIGN TABLE test_parquet (
...
) SERVER parquet_srv OPTIONS (filename 'GoogleAnalytics/test/*.parquet');
```

- Merged also support for PostgreSQL 17+